### PR TITLE
Change deprecated gradle feature 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    implementation 'com.android.support:support-v4:18.0.0'
 }


### PR DESCRIPTION
I have switched gradle to use the 'implementation' keyword instead of compile. This needed to be fixed by the end of 2018.