### PR TITLE
Bug fix: stop system initialisation deleting ships

### DIFF
--- a/app/src/main/java/dadeindustries/game/gc/model/GlobalGameData.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/GlobalGameData.java
@@ -4,7 +4,6 @@ import android.util.Log;
 
 import dadeindustries.game.gc.model.Enums.Faction;
 import dadeindustries.game.gc.model.FactionArtifacts.Ship;
-import dadeindustries.game.gc.model.FactionArtifacts.Unit;
 import dadeindustries.game.gc.model.StellarPhenomenon.Phenomena.System;
 import dadeindustries.game.gc.model.StellarPhenomenon.Sector;
 
@@ -36,21 +35,21 @@ public class GlobalGameData {
 				sectors[i][j] = new Sector(i, j);
 			}
 		}
-		loadTestShips();
-		loadTestPlanets();
+		insertTestShips();
+		insertTestSystems();
 	}
 
 	//FUNCTIONS
 
-	private void loadTestShips() {
+	private void insertTestShips() {
 		sectors[2][2].addShip(new Ship(sectors[2][2], Faction.UNITED_PLANETS, "HMS Douglas"));
-		sectors[3][4].addShip(new Ship(sectors[0][0], Faction.MORPHERS, "ISS Yuri"));
+		sectors[2][3].addShip(new Ship(sectors[2][3], Faction.MORPHERS, "ISS Yuri"));
 		sectors[1][1].addShip(new Ship(sectors[1][1], Faction.UNITED_PLANETS, "USS Dade"));
 	}
 
-	private void loadTestPlanets() {
-		sectors[3][4] = new Sector(2, 3, new System("Planet X", 3, 4));
-		sectors[4][4] = new Sector(3, 3, new System("Planet Y", 3, 4));
+	private void insertTestSystems() {
+		sectors[2][3].setSystem(new System("Planet X", 2, 3));
+		sectors[3][3].setSystem(new System("Planet Y", 3, 3));
 
 		for (int i = 0; i < GlobalGameData.galaxySizeX; i++) {
 			for (int j = 0; j < GlobalGameData.galaxySizeY; j++) {

--- a/app/src/main/java/dadeindustries/game/gc/model/StellarPhenomenon/Sector.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/StellarPhenomenon/Sector.java
@@ -42,6 +42,10 @@ public class Sector {
 		return system;
 	}
 
+	public void setSystem(System system) {
+		this.system = system;
+	}
+
 	public int getX() {
 		return x;
 	}


### PR DESCRIPTION
The way new systems were being added was reinstantiating sectors with
new sectors, then placing systems somewhere else.

This has been fixed by the addition of the setSystem(System) method to
the Sector class, so that the sector can be given a system without
having to be recreated.

It should also be noted that it is possible to instantiate ships and
systems that think they're in different sectors than the ones they're
being stored in. This hasn't created any known bugs for systems, but
ships move based on where they think they are, not where they actually
are, so their first move is sometimes in the wrong direction. We should
look into some way of only being able to supply a single position when
creating anything that has a position.