### PR TITLE
Feature/colony errors

### DIFF
--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -475,15 +475,34 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 				null);
 	}
 
+	/**
+	 * Show error message in a dialog box to the player
+	 * @param message
+	 */
+	public void showError(String message) {
+		AlertDialog.Builder builder =
+				new AlertDialog.Builder(ctxt).
+						setTitle("Error").
+						setMessage(message).
+						setIcon(android.R.drawable.ic_dialog_info).
+						setPositiveButton("OK", new DialogInterface.OnClickListener() {
+							@Override
+							public void onClick(DialogInterface dialog, int which) {
+								dialog.dismiss();
+							}
+						});
+		builder.create().show();
+	}
+
 	public void showShipMenu(final Spaceship ship) {
-		CharSequence colors[] = new CharSequence[]{
+		final CharSequence orders[] = new CharSequence[]{
 				SpacecraftOrder.MOVE.name(),
 				SpacecraftOrder.ATTACK.name(),
 				SpacecraftOrder.COLONISE.name()};
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(ctxt);
 		builder.setTitle(ship.getClass().getSimpleName());
-		builder.setItems(colors, new DialogInterface.OnClickListener() {
+		builder.setItems(orders, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
 				// the user clicked on colors[which]
@@ -508,11 +527,11 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 									((ColonyShip) selectedShip).colonise();
 									makeToast("Colonising...");
 								} else {
-									makeToast("Already colonised " +
+									showError("This system is already colonised " +
 											sectors[currentX][currentY].getSystem().hasFaction());
 								}
 							} else {
-								makeToast("Nothing to colonise");
+								showError("This system cannot be colonised");
 							}
 						}
 						break;

--- a/app/src/main/java/dadeindustries/game/gc/view/Start.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/Start.java
@@ -171,8 +171,11 @@ public class Start extends Activity {
 		dialog.setIcon(android.R.drawable.ic_popup_sync);
 		dialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {
 			public void onClick(DialogInterface dialog, int id) {
-				// Deliberately empty. Just dismisses the popup.
-				finish();
+				// TODO: Restart the application
+				// Currently it closes
+				moveTaskToBack(true);
+				android.os.Process.killProcess(android.os.Process.myPid());
+				System.exit(0);
 			}
 		});
 		dialog.create().show();
@@ -202,7 +205,9 @@ public class Start extends Activity {
 				.setPositiveButton("Yes",
 						new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int id) {
-								finish();
+								moveTaskToBack(true);
+								android.os.Process.killProcess(android.os.Process.myPid());
+								System.exit(1);
 							}
 						})
 				.setNegativeButton("No", new DialogInterface.OnClickListener() {


### PR DESCRIPTION

* New "showError" dialog box for any player mistakes 
* Dialog box shown when colonisation cannot be achieved (helps debug #86)
* Exiting an app now actually exits (using system.exit()). There were issues before where calls to finish() still left variables intact on app relaunch, causing side-effects like a larger grid on each app launch. 