### PR TITLE
Bug 87: Wrong ships being built

### DIFF
--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -603,7 +603,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 									4);
 							system.addToQueue(combat);
 							makeToast("Building combat ship");
-
+							break;
 						case 1:
 							// Build Colonyship
 							ColonyShip colony = new ColonyShip(
@@ -615,6 +615,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 									4);
 							system.addToQueue(colony);
 							makeToast("Building colony ship");
+							break;
 					}
 				}
 			});


### PR DESCRIPTION
Whenever a human built a combat ship, a colony ship was built
afterwards. This turned out to be because of a lack of break statements
between switch statement clauses.

Fixes #87 