### PR TITLE
Prevent unsupported screen orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
 		<!-- before was android:style/AppTheme -->
 		<activity
 			android:name="dadeindustries.game.gc.view.Start"
+			android:screenOrientation="portrait"
 			android:label="@string/app_name">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
In order to improve the UI we need to limit the different types of screen we want to support. This patch disables the app from entering landscape mode (when you turning the phone/tablet to the side). 

At some point we may re-enable this once the UI has been improved to a satisfactory level (supporting tablet+phone, with low and high DPI).