### PR TITLE
Fix for multiple ship labels

### DIFF
--- a/app/src/main/java/dadeindustries/game/gc/mechanics/turn/TurnProcessor.java
+++ b/app/src/main/java/dadeindustries/game/gc/mechanics/turn/TurnProcessor.java
@@ -48,6 +48,8 @@ public class TurnProcessor {
 
 		processConflicts(globalGameData, events); // handle unit battles
 
+		updatePlayerVisibility(globalGameData);
+
 		// Detect if a player has won the game
 		Player didAnyoneWin = detectWinCondition(globalGameData);
 
@@ -238,6 +240,25 @@ public class TurnProcessor {
 						iterator.remove();
 					}
 				}
+			}
+		}
+	}
+
+	private void updatePlayerVisibility(GlobalGameData globalGameData) {
+
+		for (Player player : globalGameData.getPlayers()) {
+
+			ArrayList<Spaceship> ships = getAllShipsForPlayer(globalGameData.getSectors(), player);
+
+			player.removeAllVisibility();
+
+			for (Spaceship ship : ships) {
+
+				int scanStrength = ship.getScanStrength();
+				int x = ship.getX();
+				int y = ship.getY();
+
+				player.makeVisible(globalGameData.getSectors()[x][y]);
 			}
 		}
 	}

--- a/app/src/main/java/dadeindustries/game/gc/mechanics/turn/TurnProcessor.java
+++ b/app/src/main/java/dadeindustries/game/gc/mechanics/turn/TurnProcessor.java
@@ -2,6 +2,7 @@ package dadeindustries.game.gc.mechanics.turn;
 
 import android.util.Log;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -63,7 +64,7 @@ public class TurnProcessor {
 		return events;
 	}
 
-	private ArrayList<Spaceship> getAllShipsForPlayer(Sector[][] sectors, Player player) {
+	private static ArrayList<Spaceship> getAllShipsForPlayer(Sector[][] sectors, Player player) {
 
 		ArrayList<Spaceship> returnShips = new ArrayList<Spaceship>();
 
@@ -79,7 +80,7 @@ public class TurnProcessor {
 		return returnShips;
 	}
 
-	private ArrayList<System> getAllSystemsForPlayer(Sector[][] sectors, Player player) {
+	private static ArrayList<System> getAllSystemsForPlayer(Sector[][] sectors, Player player) {
 
 		ArrayList returnSystems = new ArrayList();
 
@@ -244,7 +245,7 @@ public class TurnProcessor {
 		}
 	}
 
-	private void updatePlayerVisibility(GlobalGameData globalGameData) {
+	public static void updatePlayerVisibility(GlobalGameData globalGameData) {
 
 		for (Player player : globalGameData.getPlayers()) {
 
@@ -252,13 +253,26 @@ public class TurnProcessor {
 
 			player.removeAllVisibility();
 
+			ArrayList<System> systems = getAllSystemsForPlayer(globalGameData.getSectors(), player);
+			for (System system : systems) {
+				player.makeVisible(globalGameData.getSectors()[system.getX()][system.getY()]);
+			}
+
 			for (Spaceship ship : ships) {
 
 				int scanStrength = ship.getScanStrength();
-				int x = ship.getX();
-				int y = ship.getY();
 
-				player.makeVisible(globalGameData.getSectors()[x][y]);
+				for (int x = (ship.getX() - scanStrength); x < (ship.getX() + scanStrength + 1); x++) {
+
+					for (int y = (ship.getY() - scanStrength); y < (ship.getY() + scanStrength + 1); y++) {
+						if (x >= 0 && x < globalGameData.galaxySizeX) {
+
+							if (y >= 0 && y < globalGameData.galaxySizeY) {
+								player.makeVisible(globalGameData.getSectors()[x][y]);
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/app/src/main/java/dadeindustries/game/gc/model/GlobalGameData.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/GlobalGameData.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import java.util.ArrayList;
 
 import dadeindustries.game.gc.ai.Mind;
+import dadeindustries.game.gc.mechanics.turn.TurnProcessor;
 import dadeindustries.game.gc.model.enums.Extant;
 import dadeindustries.game.gc.model.enums.Faction;
 import dadeindustries.game.gc.model.enums.Intelligence;
@@ -41,6 +42,7 @@ public class GlobalGameData {
 		createTestMinds();
 		insertTestSystems();
 		insertTestShips();
+		TurnProcessor.updatePlayerVisibility(this);
 	}
 
 	public static ArrayList<Player> getPlayers() {

--- a/app/src/main/java/dadeindustries/game/gc/model/factionartifacts/Spaceship.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/factionartifacts/Spaceship.java
@@ -21,6 +21,7 @@ public abstract class Spaceship implements Spacecraft {
 	private ArrayDeque<Coordinates> course;
 	private int attackLevel;
 	private int currentHP;
+	private int scanStrength = 1;
 
 	public Spaceship(Player player, Sector currentLocation, Faction faction, String shipName, int attackLevel, int startingHP) {
 		this.player = player;
@@ -88,5 +89,9 @@ public abstract class Spaceship implements Spacecraft {
 
 	public List<SpacecraftOrder> getValidOrders() {
 		return validOrders;
+	}
+
+	public int getScanStrength() {
+		return scanStrength;
 	}
 }

--- a/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
@@ -78,11 +78,7 @@ public class Player {
 	}
 
 	public void removeAllVisibility() {
-		Iterator iter = visible.iterator();
-		while (iter.hasNext()) {
-			iter.remove();
-		}
-		Log.i("Visibility ", "Visiblity is " + visible.size());
+		visible.clear();
 	}
 
 	public void makeVisible(Sector s) {

--- a/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
@@ -1,8 +1,11 @@
 package dadeindustries.game.gc.model.players;
 
+import java.util.HashSet;
+
 import dadeindustries.game.gc.model.enums.Extant;
 import dadeindustries.game.gc.model.enums.Faction;
 import dadeindustries.game.gc.model.enums.Intelligence;
+import dadeindustries.game.gc.model.stellarphenomenon.Sector;
 
 public class Player {
 
@@ -11,6 +14,9 @@ public class Player {
 	private Extant extant;
 	private int credits;
 	private boolean dead = false;
+
+	private HashSet<Sector> discovered = new HashSet<Sector>();
+	private HashSet<Sector> visible = new HashSet<Sector>();
 
 	public Player(Faction faction, Intelligence intelligence, Extant extant, int credits) {
 		this.faction = faction;
@@ -50,5 +56,17 @@ public class Player {
 
 	public void surrender() {
 		dead = true;
+	}
+
+	public boolean hasDiscovered(Sector sector) {
+		return discovered.contains(sector);
+	}
+
+	public HashSet getDiscoveredSectors() {
+		return discovered;
+	}
+
+	public void discover(Sector sector) {
+		discovered.add(sector);
 	}
 }

--- a/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/players/Player.java
@@ -1,6 +1,9 @@
 package dadeindustries.game.gc.model.players;
 
+import android.util.Log;
+
 import java.util.HashSet;
+import java.util.Iterator;
 
 import dadeindustries.game.gc.model.enums.Extant;
 import dadeindustries.game.gc.model.enums.Faction;
@@ -68,5 +71,21 @@ public class Player {
 
 	public void discover(Sector sector) {
 		discovered.add(sector);
+	}
+
+	public boolean isVisible(Sector sector) {
+		return visible.contains(sector);
+	}
+
+	public void removeAllVisibility() {
+		Iterator iter = visible.iterator();
+		while (iter.hasNext()) {
+			iter.remove();
+		}
+		Log.i("Visibility ", "Visiblity is " + visible.size());
+	}
+
+	public void makeVisible(Sector s) {
+		visible.add(s);
 	}
 }

--- a/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/Sector.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/Sector.java
@@ -22,8 +22,6 @@ public class Sector {
 	private int x;
 	private int y;
 	private System system = null;
-	private HashMap<Player, Boolean> discovered = new HashMap<Player, Boolean>();
-	private HashMap<Player, Boolean> visible = new HashMap<Player, Boolean>();
 
 	private ArrayList<Spaceship> units = new ArrayList<Spaceship>();
 
@@ -68,15 +66,7 @@ public class Sector {
 
 	public void addShip(Spaceship s) {
 		units.add(s);
-		discover(s.getOwner());
-	}
-
-	public boolean isDiscovered(Player player) {
-		return discovered.containsKey(player);
-	}
-
-	public void discover(Player player) {
-		discovered.put(player, true);
+		s.getOwner().discover(this);
 	}
 
 	public ArrayList<Spaceship> getUnits() {

--- a/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/Sector.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/Sector.java
@@ -1,6 +1,7 @@
 package dadeindustries.game.gc.model.stellarphenomenon;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -21,6 +22,8 @@ public class Sector {
 	private int x;
 	private int y;
 	private System system = null;
+	private HashMap<Player, Boolean> discovered = new HashMap<Player, Boolean>();
+	private HashMap<Player, Boolean> visible = new HashMap<Player, Boolean>();
 
 	private ArrayList<Spaceship> units = new ArrayList<Spaceship>();
 
@@ -65,6 +68,15 @@ public class Sector {
 
 	public void addShip(Spaceship s) {
 		units.add(s);
+		discover(s.getOwner());
+	}
+
+	public boolean isDiscovered(Player player) {
+		return discovered.containsKey(player);
+	}
+
+	public void discover(Player player) {
+		discovered.put(player, true);
 	}
 
 	public ArrayList<Spaceship> getUnits() {

--- a/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/phenomena/System.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/phenomena/System.java
@@ -25,7 +25,9 @@ public class System {
 	public static boolean createNewSystem(String name, int x, int y, Player owner, Sector[][] sectors) {
 		if (!sectors[x][y].hasSystem()) {
 			sectors[x][y].setSystem(new System(name, x, y, owner));
-			sectors[x][y].discover(owner);
+			if (owner!=null) {
+				owner.discover(sectors[x][y]);
+			}
 			return true;
 		} else {
 			return false;

--- a/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/phenomena/System.java
+++ b/app/src/main/java/dadeindustries/game/gc/model/stellarphenomenon/phenomena/System.java
@@ -1,6 +1,7 @@
 package dadeindustries.game.gc.model.stellarphenomenon.phenomena;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import dadeindustries.game.gc.model.factionartifacts.Spaceship;
 import dadeindustries.game.gc.model.players.Player;
@@ -10,19 +11,21 @@ public class System {
 
 	private String name;
 	private int x, y;
-	private Player player;
+	private Player owner;
 	private ArrayList<QueueItem> buildQueue = new ArrayList<QueueItem>();
+	private HashMap<Player, Boolean> discovered = new HashMap<Player, Boolean>();
 
-	private System(String name, int x, int y, Player player) {
+	private System(String name, int x, int y, Player owner) {
 		this.x = x;
 		this.y = y;
 		this.name = name;
-		this.player = player;
+		this.owner = owner;
 	}
 
 	public static boolean createNewSystem(String name, int x, int y, Player owner, Sector[][] sectors) {
 		if (!sectors[x][y].hasSystem()) {
 			sectors[x][y].setSystem(new System(name, x, y, owner));
+			sectors[x][y].discover(owner);
 			return true;
 		} else {
 			return false;
@@ -67,16 +70,16 @@ public class System {
 	}
 
 	public boolean hasOwner() {
-		return player != null;
+		return owner != null;
 	}
 
 	public Player getOwner() {
-		return player;
+		return owner;
 	}
 
-	public void setOwner(Player player) {
+	public void setOwner(Player newowner) {
 		buildQueue.clear();
-		this.player = player;
+		this.owner = newowner;
 	}
 
 	class QueueItem {

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -188,12 +188,21 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 				r.bottom = y + (SQUARE_SIZE / 2) * 2;
 
 				canvas.drawBitmap(p2, null, r, paint);
-				paint.setColor(Color.WHITE);
-				paint.setTextSize(16 * getResources().getDisplayMetrics().density);
-				canvas.drawText(sector.getSystem().getName(), x + PADDING, y
-						+ (SQUARE_SIZE / 2), paint);
-				paint.setColor(savedColor);
 			}
+		}
+	}
+
+	public void drawSystemLabel(Canvas canvas, Sector sector) {
+		if (sector.hasSystem()) {
+			int savedColor = paint.getColor();
+			paint.setColor(Color.WHITE);
+			paint.setTextSize(16 * getResources().getDisplayMetrics().density);
+			canvas.drawText(sector.getSystem().getName(),
+					(SQUARE_SIZE * sector.getX()) + PADDING,
+					SQUARE_SIZE * sector.getY()
+					+ (SQUARE_SIZE / 2),
+					paint);
+			paint.setColor(savedColor);
 		}
 	}
 
@@ -342,6 +351,11 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 		}
 
 		drawGrid(canvas);
+
+		for (Object s : globalGameData.getHumanPlayer().getDiscoveredSectors()) {
+			drawSystemLabel(canvas, (Sector) s);
+		}
+
 		drawTopLeftInformation(canvas);
 	}
 

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -168,7 +168,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 	}
 
 	public void drawSystem(Sector sector, Canvas canvas) {
-		if (sector.hasSystem() && sector.isDiscovered(globalGameData.getHumanPlayer())) {
+		if (sector.hasSystem() && globalGameData.getHumanPlayer().hasDiscovered(sector)) {
 
 			int x, y;
 			int savedColor = paint.getColor();
@@ -244,11 +244,16 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 	 * @param canvas
 	 */
 	public void drawTopLeftInformation(Canvas canvas) {
+
+		// Save colour before using it
+		int savedColor = paint.getColor();
+		paint.setColor(Color.WHITE);
 		// Put text in top left corner indicating the current turn number
 		canvas.drawText("Turn " + globalGameData.getTurn(),
 				viewPort.x + PADDING, viewPort.y + PADDING * 3, paint);
 		canvas.drawText("Credits " + globalGameData.getHumanPlayerCredits(),
 				viewPort.x + PADDING, viewPort.y + PADDING * 3 * 2, paint);
+		paint.setColor(savedColor);
 	}
 
 	/**
@@ -262,10 +267,10 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 		int shipx = sector.getX();
 		int shipy = sector.getY();
 
-		if ((shipx >= viewPort.x)
+		if (	(shipx >= viewPort.x)
 				&& (shipx <= viewPort.x + NUM_SQUARES_IN_ROW)
 				&& (shipy >= viewPort.y)
-				&& sector.isDiscovered(globalGameData.getHumanPlayer())
+				&& globalGameData.getHumanPlayer().hasDiscovered((sector))
 				) {
 
 			x = (shipx - viewPort.x) * SQUARE_SIZE;
@@ -283,7 +288,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 				switch (ship.getOwner().getIntelligence()) {
 
 					case HUMAN:
-						sector.discover(getGlobalGameData().getHumanPlayer());
+						getGlobalGameData().getHumanPlayer().discover(sector);
 						canvas.drawBitmap(up, null, r, paint);
 						break;
 
@@ -315,7 +320,8 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 				Sector sector = sectors[i][j];
 
 				// Draw a purple square if unexplored
-				if (sector.isDiscovered(globalGameData.getHumanPlayer())) {
+				if (globalGameData.getHumanPlayer().hasDiscovered(sector)) {
+					//if (sector.isDiscovered(globalGameData.getHumanPlayer())) {
 					paint.setColor(Color.BLACK);
 				} else {
 					paint.setColor(Color.DKGRAY);
@@ -526,10 +532,12 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 		}
 
 		if (sectors[gameCoods.x][gameCoods.y].hasSystem()) {
-			return true;
-		} else {
-			return false;
+			if (globalGameData.getHumanPlayer().hasDiscovered(sectors[gameCoods.x][gameCoods.y])) {
+				return true;
+			}
 		}
+
+		return false;
 	}
 
 

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -34,6 +34,7 @@ import dadeindustries.game.gc.model.GlobalGameData;
 import dadeindustries.game.gc.model.enums.SpacecraftOrder;
 import dadeindustries.game.gc.model.factionartifacts.ColonyShip;
 import dadeindustries.game.gc.model.factionartifacts.CombatShip;
+import dadeindustries.game.gc.model.factionartifacts.Spacecraft;
 import dadeindustries.game.gc.model.factionartifacts.Spaceship;
 import dadeindustries.game.gc.model.players.Player;
 import dadeindustries.game.gc.model.stellarphenomenon.Sector;
@@ -195,7 +196,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 	public void drawSystemLabel(Canvas canvas, Sector sector) {
 		if (sector.hasSystem()) {
 			int savedColor = paint.getColor();
-			paint.setColor(Color.WHITE);
+			paint.setColor(Color.CYAN);
 			paint.setTextSize(16 * getResources().getDisplayMetrics().density);
 			canvas.drawText(sector.getSystem().getName(),
 					(SQUARE_SIZE * sector.getX()) + PADDING,
@@ -204,6 +205,37 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 					paint);
 			paint.setColor(savedColor);
 		}
+	}
+
+	public void drawShipLabel(Canvas canvas, Sector sector) {
+
+		ArrayList<Spaceship> ships = sector.getUnits(globalGameData.getHumanPlayer());
+
+		if (ships.size() > 0) {
+
+			int savedColor = paint.getColor(); // Save paint colour
+
+			paint.setColor(Color.WHITE);
+			paint.setTextSize(16 * getResources().getDisplayMetrics().density);
+
+			String text = "";
+
+			if (ships.size() > 1) {
+				text = ships.size() + " ships";
+
+			} else {
+				text = ships.get(0).getShipName();
+			}
+
+			canvas.drawText(text,
+						(SQUARE_SIZE * sector.getX()) + PADDING,
+						SQUARE_SIZE * sector.getY()
+								+ (PADDING * 3),
+						paint);
+
+			paint.setColor(savedColor); // Restore paint colour
+		}
+
 	}
 
 	public void drawGrid(Canvas canvas) {
@@ -309,9 +341,10 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 						// do nothing
 				}
 
-				paint.setColor(Color.WHITE);
-				canvas.drawText(ship.getShipName(), x + PADDING, y + (PADDING * 3)
-						+ (SQUARE_SIZE / 2), paint);
+				drawShipLabel(canvas, sector);
+				//paint.setColor(Color.WHITE);
+				//canvas.drawText(ship.getShipName(), x + PADDING, y + (PADDING * 3)
+				//		+ (SQUARE_SIZE / 2), paint);
 			}
 		}
 	}

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -170,6 +170,102 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 
 		final int PADDING = 10;
 
+
+		// TODO: Draw purple squares for all unexplored areas
+
+		for (int i = 0; i < GlobalGameData.galaxySizeX; i++) {
+			for (int j = 0; j < GlobalGameData.galaxySizeY; j++) {
+
+				int systemX = sectors[i][j].getX();
+				int systemY = sectors[i][j].getY();
+
+				if (sectors[i][j].isDiscovered(globalGameData.getHumanPlayer())) {
+					paint.setColor(Color.BLACK);
+				} else {
+					paint.setColor(Color.DKGRAY);
+				}
+
+				int x = (systemX - viewPort.x) * SQUARE_SIZE;
+				int y = (systemY - viewPort.y) * SQUARE_SIZE;
+				r.left = x;
+				r.top = y;
+				r.right = x + (SQUARE_SIZE) ;
+				r.bottom = y + (SQUARE_SIZE);
+				canvas.drawRect(r, paint);
+
+				// Draw System bitmaps
+				if (sectors[i][j].hasSystem() && sectors[i][j].isDiscovered(globalGameData.getHumanPlayer())) {
+
+					if ((systemX >= viewPort.x)
+							&& (systemX <= viewPort.x + NUM_SQUARES_IN_ROW)
+							&& (systemY >= viewPort.y)) {
+
+						x = (systemX - viewPort.x) * SQUARE_SIZE;
+						y = (systemY - viewPort.y) * SQUARE_SIZE;
+						r.left = x + (SQUARE_SIZE / 2);
+						r.top = y + (SQUARE_SIZE / 2);
+						r.right = x + (SQUARE_SIZE / 2) * 2;
+						r.bottom = y + (SQUARE_SIZE / 2) * 2;
+
+						canvas.drawBitmap(p2, null, r, paint);
+						int temp = paint.getColor();
+						paint.setColor(Color.WHITE);
+						paint.setTextSize(16 * getResources().getDisplayMetrics().density);
+						canvas.drawText(sectors[i][j].getSystem().getName(), x + PADDING, y
+								+ (SQUARE_SIZE / 2), paint);
+						paint.setColor(temp);
+					}
+				}
+
+
+				int shipx = i;
+				int shipy = j;
+
+				// Draw ships
+				if ((shipx >= viewPort.x)
+						&& (shipx <= viewPort.x + NUM_SQUARES_IN_ROW)
+						&& (shipy >= viewPort.y)
+						&& sectors[i][j].isDiscovered(globalGameData.getHumanPlayer())
+						) {
+
+					x = (shipx - viewPort.x) * SQUARE_SIZE;
+					y = (shipy - viewPort.y) * SQUARE_SIZE;
+					r.left = x;
+					r.top = y;
+					r.right = x + SQUARE_SIZE / 2;
+					r.bottom = y + SQUARE_SIZE / 2;
+
+					// TODO: Need to handle case where multiple units in the same system
+
+					ArrayList<Spaceship> ships = sectors[i][j].getUnits();
+					for (Spaceship ship : ships) {
+
+						switch (ship.getOwner().getIntelligence()) {
+
+							case HUMAN:
+								sectors[i][j].discover(getGlobalGameData().getHumanPlayer());
+								canvas.drawBitmap(up, null, r, paint);
+								break;
+
+							case ARTIFICIAL:
+								canvas.drawBitmap(mo, null, r, paint);
+								break;
+
+							default:
+								// do nothing
+						}
+
+						paint.setColor(Color.WHITE);
+						canvas.drawText(ship.getShipName(), x + PADDING, y + (PADDING * 3)
+								+ (SQUARE_SIZE / 2), paint);
+					}
+
+				}
+			}
+		}
+
+		paint.setColor(Color.WHITE);
+
 		// vertical lines
 		for (int i = viewPort.x; i <= viewPort.x + getResources().getDisplayMetrics().widthPixels; i=i+SQUARE_SIZE) {
 			canvas.drawLine(i + SQUARE_SIZE, 0, i + SQUARE_SIZE,
@@ -183,82 +279,6 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 					getResources().getDisplayMetrics().heightPixels,
 					k + SQUARE_SIZE,
 					paint);
-		}
-
-		// TODO: Draw purple squares for all unexplored areas
-
-		for (int i = 0; i < GlobalGameData.galaxySizeX; i++) {
-			for (int j = 0; j < GlobalGameData.galaxySizeY; j++) {
-				// Draw System bitmaps
-				if (sectors[i][j].hasSystem()) {
-					int systemX = sectors[i][j].getX();
-					int systemY = sectors[i][j].getY();
-
-					if ((systemX >= viewPort.x)
-							&& (systemX <= viewPort.x + NUM_SQUARES_IN_ROW)
-							&& (systemY >= viewPort.y)) {
-
-						int x = (systemX - viewPort.x) * SQUARE_SIZE;
-						int y = (systemY - viewPort.y) * SQUARE_SIZE;
-						r.left = x + (SQUARE_SIZE / 2);
-						r.top = y + (SQUARE_SIZE / 2);
-						r.right = x + (SQUARE_SIZE / 2) * 2;
-						r.bottom = y + (SQUARE_SIZE / 2) * 2;
-
-						canvas.drawBitmap(p2, null, r, paint);
-						paint.setTextSize(16 * getResources().getDisplayMetrics().density);
-						canvas.drawText(sectors[i][j].getSystem().getName(), x + PADDING, y
-								+ (SQUARE_SIZE / 2), paint);
-					}
-				}
-
-				// Units
-
-				if (sectors[i][j].hasShips() == false) {
-					continue;
-				}
-
-				int shipx = i;
-				int shipy = j;
-
-
-				if ((shipx >= viewPort.x)
-						&& (shipx <= viewPort.x + NUM_SQUARES_IN_ROW)
-						&& (shipy >= viewPort.y)) {
-
-					int x = (shipx - viewPort.x) * SQUARE_SIZE;
-					int y = (shipy - viewPort.y) * SQUARE_SIZE;
-					r.left = x;
-					r.top = y;
-					r.right = x + SQUARE_SIZE / 2;
-					r.bottom = y + SQUARE_SIZE / 2;
-
-					// TODO: Need to handle case where multiple units in the same
-					// system
-
-					ArrayList<Spaceship> ships = sectors[i][j].getUnits();
-					for (Spaceship ship : ships) {
-
-						switch (ship.getOwner().getIntelligence()) {
-
-							case HUMAN:
-								canvas.drawBitmap(up, null, r, paint);
-								break;
-
-							case ARTIFICIAL:
-								canvas.drawBitmap(mo, null, r, paint);
-								break;
-
-							default:
-								// do nothing
-						}
-
-						canvas.drawText(ship.getShipName(), x + PADDING, y + (PADDING * 3)
-								+ (SQUARE_SIZE / 2), paint);
-					}
-
-				}
-			}
 		}
 
 		// highlight current selection

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -270,7 +270,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 		if (	(shipx >= viewPort.x)
 				&& (shipx <= viewPort.x + NUM_SQUARES_IN_ROW)
 				&& (shipy >= viewPort.y)
-				&& globalGameData.getHumanPlayer().hasDiscovered((sector))
+				&& globalGameData.getHumanPlayer().isVisible(sector) == true
 				) {
 
 			x = (shipx - viewPort.x) * SQUARE_SIZE;

--- a/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
+++ b/app/src/main/java/dadeindustries/game/gc/view/GalaxyView.java
@@ -320,8 +320,7 @@ public class GalaxyView extends View implements OnTouchListener, OnKeyListener {
 				Sector sector = sectors[i][j];
 
 				// Draw a purple square if unexplored
-				if (globalGameData.getHumanPlayer().hasDiscovered(sector)) {
-					//if (sector.isDiscovered(globalGameData.getHumanPlayer())) {
+				if (globalGameData.getHumanPlayer().isVisible(sector)) {
 					paint.setColor(Color.BLACK);
 				} else {
 					paint.setColor(Color.DKGRAY);


### PR DESCRIPTION
**This is dependent on the *fog* branch pull request. Resolve that before looking at this.**

If there is more than one ship in the same sector then the name of each ship will be drawn on top of each other. This PR fixes that by showing you the number of ships you have in the sector with a label "N ships" where N is the number of ships and N > 1. 

It also changes the colour of the system label to make the labels slightly more readable. 

<img width="234" alt="image" src="https://user-images.githubusercontent.com/762640/51086369-150b8b00-173e-11e9-9423-e56c9293d92b.png">
